### PR TITLE
Add Terraform configuration for EKS cluster deployment

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -106,3 +106,13 @@ terraform destroy
 ```
 
 Type `yes` when prompted. This will delete the cluster and all associated AWS resources.
+
+## Cost Considerations
+
+Running this EKS cluster will incur AWS costs approximately:
+- EKS control plane: ~$73/month
+- 3x t3.small worker nodes: ~$46/month  
+- NAT Gateway: ~$33/month
+- **Estimated total: ~$150/month**
+
+Remember to run `terraform destroy` when not in use to avoid ongoing charges.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,108 @@
+# Frey EKS Terraform Configuration
+
+This directory contains Terraform configuration to deploy a basic EKS cluster on AWS for running Frey services.
+
+## Prerequisites
+
+- AWS account with appropriate permissions
+- AWS CLI installed and configured with credentials
+- Terraform >= 1.0
+- kubectl installed
+
+## AWS Permissions Required
+
+Your AWS user/role needs permissions to create:
+
+- VPC, subnets, route tables, internet gateways, NAT gateways
+- EKS clusters and node groups
+- IAM roles and policies
+- EC2 instances and security groups
+
+## Quick Start
+
+### 1. Initialize Terraform
+
+```bash
+terraform init
+```
+
+### 2. Review the deployment plan
+
+```bash
+terraform plan
+```
+
+### 3. Deploy the cluster
+
+```bash
+terraform apply
+```
+
+Type `yes` when prompted to confirm.
+
+### 4. Configure kubectl
+
+```bash
+aws eks update-kubeconfig --region us-east-1 --name frey-eks-cluster
+```
+
+### 5. Verify cluster access
+
+```bash
+kubectl get nodes
+```
+
+You should see 3 nodes in Ready state.
+
+## Deploying Frey Services
+
+After the cluster is running, deploy the Frey services using the Helm charts from the main repository:
+
+```bash
+# Navigate back to repository root
+cd ..
+
+# Install external-secrets operator
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace \
+  -f services/external-secrets/frey-external_secrets-values.yaml
+
+# Install NetBox
+kubectl create namespace netbox
+helm install netbox oci://ghcr.io/netbox-community/netbox-chart/netbox \
+  --namespace netbox -f services/netbox/frey-netbox-values.yaml
+
+# Install AWX
+helm repo add awx-operator https://ansible-community.github.io/awx-operator-helm
+kubectl create namespace awx-operator
+helm install awx-operator awx-operator/awx-operator \
+  --namespace awx-operator -f services/awx/frey-awx-values.yaml
+```
+
+**Note:** The current Vault configuration in `frey_bootstrap.sh` is designed for local development. For AWS deployments, you'll need to configure secrets management separately (AWS Secrets Manager or Parameter Store integration is planned for future releases).
+
+## Configuration
+
+Edit `variables.tf` to customize:
+
+- AWS region
+- Cluster name
+- Node instance type
+- Number of nodes
+
+Or override variables during apply:
+
+```bash
+terraform apply -var="aws_region=us-west-2" -var="node_instance_type=t3.medium"
+```
+
+## Cleanup
+
+To destroy all resources:
+
+```bash
+terraform destroy
+```
+
+Type `yes` when prompted. This will delete the cluster and all associated AWS resources.

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,60 @@
+# IAM roles and policies for EKS cluster and node groups
+
+# EKS Cluster IAM Role
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster_name}-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+# Attach required policies to cluster role
+resource "aws_iam_role_policy_attachment" "cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_vpc_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.cluster.name
+}
+
+# EKS Node Group IAM Role
+resource "aws_iam_role" "node_group" {
+  name = "${var.cluster_name}-node-group-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+}
+
+# Attach required policies to node group role
+resource "aws_iam_role_policy_attachment" "node_worker_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_registry_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group.name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,44 @@
+# EKS cluster and node group resources
+
+# EKS Cluster
+resource "aws_eks_cluster" "main" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster.arn
+  version  = var.cluster_version
+
+  vpc_config {
+    subnet_ids              = concat(aws_subnet.public[*].id, aws_subnet.private[*].id)
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_policy,
+    aws_iam_role_policy_attachment.cluster_vpc_policy,
+  ]
+}
+
+# EKS Node Group
+resource "aws_eks_node_group" "main" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.cluster_name}-node-group"
+  node_role_arn   = aws_iam_role.node_group.arn
+  subnet_ids      = aws_subnet.private[*].id
+  instance_types  = [var.node_instance_type]
+
+  scaling_config {
+    desired_size = var.desired_nodes
+    min_size     = var.min_nodes
+    max_size     = var.max_nodes
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_worker_policy,
+    aws_iam_role_policy_attachment.node_cni_policy,
+    aws_iam_role_policy_attachment.node_registry_policy,
+  ]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,32 @@
+# outputs.tf - Output values for cluster access and information
+
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = aws_eks_cluster.main.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = aws_eks_cluster.main.vpc_config[0].cluster_security_group_id
+}
+
+output "cluster_ca_certificate" {
+  description = "Certificate authority data for the cluster"
+  value       = aws_eks_cluster.main.certificate_authority[0].data
+  sensitive   = true
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.aws_region
+}
+
+output "configure_kubectl" {
+  description = "Command to configure kubectl"
+  value       = "aws eks update-kubeconfig --region ${var.aws_region} --name ${aws_eks_cluster.main.name}"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,16 @@
+# providers.tf - Terraform and AWS provider configuration
+
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,43 @@
+# variables.tf - Input variables for EKS cluster configuration
+
+variable "aws_region" {
+  description = "AWS region for EKS cluster"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+  default     = "frey-eks-cluster"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.30"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for worker nodes"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "desired_nodes" {
+  description = "Desired number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "min_nodes" {
+  description = "Minimum number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "max_nodes" {
+  description = "Maximum number of worker nodes"
+  type        = number
+  default     = 5
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,118 @@
+# VPC and networking resources for EKS cluster
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.cluster_name}-vpc"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.cluster_name}-igw"
+  }
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.${count.index}.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name                                        = "${var.cluster_name}-public-${count.index + 1}"
+    "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+}
+
+# Private Subnets
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index + 10}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name                                        = "${var.cluster_name}-private-${count.index + 1}"
+    "kubernetes.io/role/internal-elb"           = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+}
+
+# Elastic IP for NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.cluster_name}-nat-eip"
+  }
+}
+
+# NAT Gateway
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.cluster_name}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-public-rt"
+  }
+}
+
+# Private Route Table
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-private-rt"
+  }
+}
+
+# Associate public subnets with public route table
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Associate private subnets with private route table
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# Data source for availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}


### PR DESCRIPTION
Closes #9

   ## Summary
   Adds Terraform configuration to deploy a basic 3 node EKS cluster on AWS as an alternative to the local k3s setup.

   ## What's included
   - Terraform modules for EKS cluster, VPC, networking, and IAM
   - Complete documentation in terraform/README.md
   - Configuration for 3 t3.small worker nodes (customizable)

   ## Usage
   Users can deploy the cluster with `terraform apply`, then manually deploy Frey services using the existing Helm charts from frey_bootstrap.sh.

   ## Notes
   - Secrets management for AWS is not included (future enhancement)
   - Cost estimate provided in README (~$150/month)